### PR TITLE
Support main and master branches in git

### DIFF
--- a/bash/dotfiles/custom_scripts
+++ b/bash/dotfiles/custom_scripts
@@ -45,7 +45,7 @@ timestamp() {
 
 set_main_branch() {
   if [ -d .git ]; then
-    export GIT_MAIN=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+    export GIT_MAIN=$(git symbolic-ref refs/remotes/origin/HEAD | cut -d'/' -f4)
   fi
 }
 

--- a/bash/dotfiles/custom_scripts
+++ b/bash/dotfiles/custom_scripts
@@ -42,3 +42,16 @@ archive() {
 timestamp() {
   echo $(date +%Y%m%d-%H%M)
 }
+
+set_main_branch() {
+  if [ -d .git ]; then
+    export GIT_MAIN=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+  fi
+}
+
+cd() {
+  builtin cd "$@"
+
+  set_main_branch
+}
+

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -20,7 +20,7 @@
 	rbc = rebase --continue
 	rbs = rebase --skip
 	lg = log --name-status --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%Creset' --abbrev-commit --date=relative
-	update = !"git co master && git pull && git co - && git rebase master"
+	update = !"git co $GIT_MAIN && git pull && git co - && git rebase $GIT_MAIN"
 [push]
 	default = current
 [core]


### PR DESCRIPTION
Adds custom script running on any directory change, to set the current git main/master branch, then uses this branch in my update alias

Turns out this other way of getting the current repo's main or master
branch is much much faster
```
✔ 11:42 ~/code/transfixio/transfix [master ↓·2|⚑ 1] $ time git symbolic-ref refs/remotes/origin/HEAD | cut -d'/' -f4
master

real	0m0.012s
user	0m0.004s
sys	0m0.008s
✔ 11:42 ~/code/transfixio/transfix [master ↓·2|⚑ 1] $ time git remote show origin | grep "HEAD branch" | sed 's/.*: //'
master

real	0m1.541s
user	0m0.212s
sys	0m0.131s
```